### PR TITLE
Hinzufügen einer .gitignore Datei

### DIFF
--- a/.gitignore.txt
+++ b/.gitignore.txt
@@ -1,0 +1,5 @@
+.idea/
+lib/
+out/
+*.iml
+target

--- a/.gitignore.txt
+++ b/.gitignore.txt
@@ -2,4 +2,4 @@
 lib/
 out/
 *.iml
-target
+target/


### PR DESCRIPTION
Lösungsvorschlag für Issue #8 
Closes #8 

Hiermit wird eine .gitignore Datei erstellt, welche verhindert, dass ungewünschte Kotlin oder Maven Dateien und Ordner zum Projekt hinzugefügt werden. 