### PR TITLE
.gitignore.txt verbessert zu .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+lib/
+out/
+*.iml
+target/

--- a/.gitignore.txt
+++ b/.gitignore.txt
@@ -1,5 +1,0 @@
-.idea/
-lib/
-out/
-*.iml
-target/


### PR DESCRIPTION
Lösungsvorschlag zu Issue #31 
Closes #31 

Habe die Dateiendung der .gitignore entfernt. Dazu wurde in git mit `touch gitignore` die neue Datei ohne Dateiendung erstellt. Inhalt der alten `.gitignore.txt` wurde übernommen und dann gelöscht.