### PR TITLE
Dateityp von .gitignore berichtigt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+lib/
+out/
+*.iml
+target/


### PR DESCRIPTION
Lösungsvorschlag zu Issue #31  Closes Issue #31 

Der Inhalt der .gitignore.txt wurde in die Datei .gitignore überführt