### PR TITLE
Hauptklasse im pom berichtigt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<kotlin.version>1.1.3-2</kotlin.version>
-		<main.class>MainKt</main.class>
+		<main.class>traffic_simulation.MainKt</main.class>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Lösung für Issue #49 
Closes #49 

Der Pfad der Hauptklasse in der pom.xml ist nun wieder erreichbar.

Habs getestet - die .jar lässt sich wieder ausführen.