### PR TITLE
Double-Werte in RoadNetworkTest zu Int-Werten gemacht

### DIFF
--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -7,40 +7,40 @@ class RoadNetworkTest {
 
     @Test
     fun doesCalculateDemandWork() {
-        val road = RoadNetwork(20.0)
+        val road = RoadNetwork(20)
 
-        val BMW     : Vehicle = Vehicle(1.0)
-        val AUDI    : Vehicle = Vehicle(1.0)
-        val VOLVO   : Vehicle = Vehicle(1.0)
+        val BMW     : Vehicle = Vehicle(1 , true)
+        val AUDI    : Vehicle = Vehicle(1 , true)
+        val VOLVO   : Vehicle = Vehicle(1 , true)
 
         val cars : List<Vehicle> = listOf(BMW,AUDI,VOLVO)
 
         val calculated = road.calculateDemand(cars)
 
-        assertEquals(3.0,calculated,0.001)
+        assertEquals(3,calculated)
     }
 
     @Test
     fun doesCheckForTrafficJamWorkForCapacityBiggerThanDemand() {
-        val road = RoadNetwork(20.0)
+        val road = RoadNetwork(20)
 
-        val trafficJam : Boolean = road.checkForTrafficJam(3.0)
+        val trafficJam : Boolean = road.checkForTrafficJam(3)
         assertEquals(false,trafficJam)
     }
 
     @Test
     fun doesCheckForTrafficJamWorkForCapacitySmallerThanDemand() {
-        val road = RoadNetwork(2.0)
+        val road = RoadNetwork(2)
 
-        val trafficJam : Boolean = road.checkForTrafficJam(3.0)
+        val trafficJam : Boolean = road.checkForTrafficJam(3)
         assertEquals(true,trafficJam)
     }
 
     @Test
     fun doesCheckForTrafficJamWorkForCapacityEqualToDemand() {
-        val road = RoadNetwork(3.0)
+        val road = RoadNetwork(3)
 
-        val trafficJam : Boolean = road.checkForTrafficJam(3.0)
+        val trafficJam : Boolean = road.checkForTrafficJam(3)
         assertEquals(false,trafficJam)
     }
 


### PR DESCRIPTION
Lösung für Issue #52 
Closes #52 

Wir sind wegen den Rundungsfehlern auf Int-Werte umgestiegen. In der Testklasse [RoadNetworkTest](https://github.com/RF-Buerky/BBFW-Project/blob/code/src/test/kotlin/RoadNetworkTest.kt) waren noch Double-Werte vorhanden. Diese sind nun zu Int-Werten geändert.