### PR TITLE
weitere Tests für RoadNetwork und mitbringende Anpassungen

### DIFF
--- a/src/main/kotlin/traffic_simulation/RoadNetwork.kt
+++ b/src/main/kotlin/traffic_simulation/RoadNetwork.kt
@@ -14,6 +14,7 @@ class RoadNetwork(val capacity : Int){
         val gatheredPlansToDrive : MutableList<Vehicle> = mutableListOf()
 
         for (vehicle in allVehiclesPlans){
+            vehicle.newVehicle(vehicle)
             if (vehicle.wannaDrive()){
                 gatheredPlansToDrive.add(vehicle)
                 vehiclesPlanningToDrive.add(vehicle)
@@ -26,11 +27,12 @@ class RoadNetwork(val capacity : Int){
 
     fun calculateDemand(vehiclesDrivingPlans:List<Vehicle>): Int{
 
+        val safedVehiclesDrivingPlans : MutableList<Vehicle> = gatherPlansToDrive(vehiclesDrivingPlans)
         // a list of vehicles given to the function gets screened for the capacityFactor attribute
         //and adds these Doubles to a total capacity demand for this scenario (=1 hour)
         var capacityDemand : Int = 0
 
-        for (vehicle in vehiclesDrivingPlans){
+        for (vehicle in safedVehiclesDrivingPlans){
             capacityDemand = capacityDemand + 1
             capacityLoadByInterests = capacityLoadByInterests +1
             }

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -1,10 +1,25 @@
 package traffic_simulation
 
 class Vehicle(val id : Int, val wannaDrive : Boolean, var delayed : Boolean = false){
-    //Methods to be added here soon
 
-    fun newVehicle (id : Int , wannaDrive : Boolean) : Vehicle {
-        return Vehicle(id , wannaDrive)
+    val allVehicles : MutableList<Vehicle> = mutableListOf()
+
+    fun isNewVehicle (newVehicle : Vehicle) : Boolean {
+        var isNew : Boolean = true
+        for (vehicle in allVehicles){
+            if (vehicle.id == newVehicle.id){
+                isNew = false
+            }
+        }
+        return isNew
+    }
+
+    fun newVehicle (vehicle : Vehicle): Vehicle{
+        if (isNewVehicle(vehicle)) {
+            allVehicles.add(vehicle)
+        }
+
+        return Vehicle(id, wannaDrive)
     }
 
     fun wannaDrive (): Boolean {

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -6,19 +6,83 @@ import traffic_simulation.Vehicle
 class RoadNetworkTest {
 
     @Test
+    fun gatherPlansToDriveGathersJustTrueDriveplans (){
+
+        val road = RoadNetwork(20)
+
+        val car1 : Vehicle = Vehicle(1, true)
+        val car2 : Vehicle = Vehicle(2, false)
+        val car3 : Vehicle = Vehicle(3, true)
+        val car4 : Vehicle = Vehicle(4, false)
+        val car5 : Vehicle = Vehicle(5, false)
+        val car6 : Vehicle = Vehicle(6, false)
+
+        val allVehicles : List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        val gatheredPlansToDrive : List<Vehicle> = road.gatherPlansToDrive(allVehicles)
+
+        var i : Int = 0
+
+        for (plan in gatheredPlansToDrive){
+            i = i + 1
+        }
+
+        assertEquals(2, i)
+    }
+
+    @Test
+    fun gatherPlansToDriveGathersJustTrueDriveplans2 (){
+
+        val road = RoadNetwork(20)
+
+        val car1 : Vehicle = Vehicle(1, false)
+        val car2 : Vehicle = Vehicle(2, false)
+        val car3 : Vehicle = Vehicle(3, false)
+        val car4 : Vehicle = Vehicle(4, false)
+
+        val allVehicles : List<Vehicle> = listOf(car1, car2, car3, car4)
+
+        val gatheredPlansToDrive : List<Vehicle> = road.gatherPlansToDrive(allVehicles)
+
+        var i : Int = 0
+
+        for (plan in gatheredPlansToDrive){
+            i = i + 1
+        }
+
+        assertEquals(0, i)
+    }
+
+    @Test
     fun doesCalculateDemandWork() {
+
         val road = RoadNetwork(20)
 
         val BMW     : Vehicle = Vehicle(1, true)
         val AUDI    : Vehicle = Vehicle(2, true)
         val VOLVO   : Vehicle = Vehicle(3, true)
 
-
-        val cars : List<Vehicle> = listOf(BMW,AUDI,VOLVO)
+        val cars : List<Vehicle> = listOf(BMW, AUDI, VOLVO)
 
         val calculated = road.calculateDemand(cars)
 
-        assertEquals(3,calculated)
+        assertEquals(3, calculated)
+    }
+
+    @Test
+    fun calculateDemandCalculatesJustWannaDriveCars() {
+
+        val road = RoadNetwork(20)
+
+        val BMW     : Vehicle = Vehicle(1, true)
+        val AUDI    : Vehicle = Vehicle(2, false)
+        val VOLVO   : Vehicle = Vehicle(3, false)
+
+        val cars : List<Vehicle> = listOf(BMW, AUDI, VOLVO)
+
+        val calculated = road.calculateDemand(cars)
+
+        assertEquals(1, calculated)
     }
 
     @Test
@@ -45,4 +109,82 @@ class RoadNetworkTest {
         assertEquals(false,trafficJam)
     }
 
+    @Test
+    fun doesScenarioGiveRightAmountOfOutput(){
+
+        val road = RoadNetwork(10)
+
+        val car1 : Vehicle = Vehicle (1, true)
+        val car2 : Vehicle = Vehicle (2, false)
+        val car3 : Vehicle = Vehicle (3, true)
+        val car4 : Vehicle = Vehicle (4, false)
+        val car5 : Vehicle = Vehicle (5, false)
+        val car6 : Vehicle = Vehicle (6, false)
+
+        val allVehicles : List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        val output : List<Vehicle> = road.scenario(allVehicles)
+
+        var i : Int = 0
+
+        for (plan in output){
+            i = i + 1
+        }
+
+        assertEquals(2, i)
+    }
+
+    @Test
+    fun doesScenarioGiveRightAmountOfDelays(){
+
+        val road = RoadNetwork(3)
+
+        val car1 : Vehicle = Vehicle (1, true)
+        val car2 : Vehicle = Vehicle (2, false)
+        val car3 : Vehicle = Vehicle (3, true)
+        val car4 : Vehicle = Vehicle (4, false)
+        val car5 : Vehicle = Vehicle (5, true)
+        val car6 : Vehicle = Vehicle (6, true)
+
+        val allVehicles : List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        val output : List<Vehicle> = road.scenario(allVehicles)
+
+        var i : Int = 0
+
+        for (plan in output){
+            if(plan.delayed == true){
+                i = i + 1
+            }
+        }
+
+        assertEquals(4, i)
+    }
+
+    @Test
+    fun doesScenarioGiveRightAmountOfNotDelays(){
+
+        val road = RoadNetwork(5)
+
+        val car1 : Vehicle = Vehicle (1, true)
+        val car2 : Vehicle = Vehicle (2, false)
+        val car3 : Vehicle = Vehicle (3, true)
+        val car4 : Vehicle = Vehicle (4, true)
+        val car5 : Vehicle = Vehicle (5, true)
+        val car6 : Vehicle = Vehicle (6, false)
+
+        val allVehicles : List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        val output : List<Vehicle> = road.scenario(allVehicles)
+
+        var i : Int = 0
+
+        for (plan in output){
+            if (plan.delayed == false){
+                i = i + 1
+            }
+        }
+        println(i)
+        assertEquals (4, i)
+    }
 }


### PR DESCRIPTION
Issue #56  (Close #56 )

**Frage zu Scenario in Verbindung mit den zugehörigen Tests:**
Wenn 4 Autos fahren möchten, die Straße aber nur 3 zulässt, ist doch nur einen vorhanden das als "verspätet" gesetzt werden soll/kann. die Funktion Scenario schaut sich an wie hoch die Nachfrage ist, vergleicht dann mit der Kapazität der Straße und setzt alle Autos auf delayed. Folglich gibt Scenario den Wert 4 aus.
Oder wie seht Ihr das?

PS: Ein Kommentar hab ich vergessen: "Anpassung von gatherPlansToDrive und calculateDemand"