### PR TITLE
Tests für RoadNetwork und Vehicle

### DIFF
--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -38,7 +38,7 @@ fun testScenarioWithInternList() {
     val testList: List<Vehicle> = listOf(BMW1, BMW2, BMW3, BMW4, BMW5, BMW6, BMW7, BMW8, BMW9, BMW10, BMW11, BMW12)
 
     for (vehicle in road.simulateScenario(testList)) {
-        println("Vehicle '${vehicle.id}' is delayed: ${vehicle.delayedInHours}")
+        println("Vehicle '${vehicle.id}' is delayed: ${vehicle.gotNewDelayInHours}")
     }
 }
 
@@ -100,7 +100,7 @@ fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv"
 
         for (result in results) {
             val id = result.id.toString()
-            val delay = result.delayedInHours.toString()
+            val delay = result.gotNewDelayInHours.toString()
             val row: Array<Any> = arrayOf(id, delay)
             vehicleRows.add(row)
         }

--- a/src/main/kotlin/traffic_simulation/RoadNetwork.kt
+++ b/src/main/kotlin/traffic_simulation/RoadNetwork.kt
@@ -2,24 +2,42 @@ package traffic_simulation
 
 class RoadNetwork(val capacity: Int) {
 
-    fun calculateDemandForTimestepAndCauseTrafficJam(timestep :Int, vehicleList: List<Vehicle>): Int{
-        var demandAtTimestep :Int =0
+    fun calculateDemandForTimestepAndCauseTrafficJam(timestep :Int, vehicleList: List<Vehicle>){
 
+        val demandAtTimestep :Int = calculateDemandAtTimestep(vehicleList , timestep)
+
+        val trafficJam : Boolean = isTrafficJam(demandAtTimestep)
+        if(trafficJam){
+            delayVehiclesInTimestep(vehicleList , timestep)
+        } else {
+            vehiclesDrivingInTimestep(vehicleList , timestep)
+        }
+    }
+
+    fun calculateDemandAtTimestep (vehicleList : List<Vehicle> , timestep : Int):Int{
+        var demandAtTimestep : Int = 0
         for(vehicle in vehicleList){
             if(vehicle.vehicleWantsToDriveAt(timestep)){
                 demandAtTimestep = demandAtTimestep +1
             }
         }
-        if(demandAtTimestep>capacity){
-            for(vehicle in vehicleList){
-                vehicle.getDelayedAtHour(timestep)
-            }
-        } else {
-            for(vehicle in vehicleList){
-                vehicle.driveAtHour(timestep)
-            }
+        return demandAtTimestep
+    }
+
+    fun isTrafficJam (demandAtTimestep : Int): Boolean{
+        return (demandAtTimestep > capacity)
+    }
+
+    fun delayVehiclesInTimestep (vehicleList : List<Vehicle> , timestep : Int){
+        for(vehicle in vehicleList){
+            vehicle.getDelayedAtHour(timestep)
         }
-       return demandAtTimestep
+    }
+
+    fun vehiclesDrivingInTimestep (vehicleList: List<Vehicle>, timestep: Int){
+        for(vehicle in vehicleList){
+            vehicle.driveAtHour(timestep)
+        }
     }
 
     fun simulateScenario(vehicleList: List<Vehicle>): List<Vehicle> {

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -2,7 +2,7 @@ package traffic_simulation
 
 class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
 
-    val delayedInHours : MutableList<Int> = mutableListOf()
+    val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     var delay = 0
 
     fun vehicleWantsToDriveAt(timestep :Int):Boolean{
@@ -16,8 +16,8 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
         // (otherwise it just waited an hour, not reducing its delay)
         if (wannaDriveInHours.contains(timestep)) {
             delay += 1
-            this.delayedInHours.add(timestep)
-            this.delayedInHours.sort()
+            this.gotNewDelayInHours.add(timestep)
+            this.gotNewDelayInHours.sort()
         }
     }
 

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -18,7 +18,6 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
             delay += 1
             this.delayedInHours.add(timestep)
             this.delayedInHours.sort()
-            this.wannaDriveInHours.add(timestep + 1)
         }
     }
 

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -18,6 +18,7 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
             delay += 1
             this.delayedInHours.add(timestep)
             this.delayedInHours.sort()
+            this.wannaDriveInHours.add(timestep + 1)
         }
     }
 

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -13,7 +13,7 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW)
 
-        val calculated = road.calculateDemandAtTimestep(cars , 1)
+        val calculated = road.calculateDemandAtTimestep(cars, 1)
 
         assertEquals(1, calculated)
     }
@@ -26,7 +26,7 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW)
 
-        val calculated = road.calculateDemandAtTimestep(cars , 24)
+        val calculated = road.calculateDemandAtTimestep(cars, 24)
 
         assertEquals(1, calculated)
     }
@@ -37,7 +37,7 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf()
 
-        val calculated = road.calculateDemandAtTimestep(cars , 5)
+        val calculated = road.calculateDemandAtTimestep(cars, 5)
 
         assertEquals(0, calculated)
     }
@@ -52,7 +52,7 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW, AUDI, VOLVO)
 
-        val calculated = road.calculateDemandAtTimestep(cars , 5)
+        val calculated = road.calculateDemandAtTimestep(cars, 5)
 
         assertEquals(3, calculated)
     }
@@ -67,7 +67,7 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW, AUDI, VOLVO)
 
-        val calculated = road.calculateDemandAtTimestep(cars , 5)
+        val calculated = road.calculateDemandAtTimestep(cars, 5)
 
         assertEquals(3, calculated)
     }
@@ -131,6 +131,47 @@ class RoadNetworkTest {
     }
 
     @Test
+    fun delayVehiclesInTimestep_someVehiclesThere_allVehiclesGetingDelayed() {
+        val road = RoadNetwork(0)
+
+        val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car2: Vehicle = Vehicle(2, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car3: Vehicle = Vehicle(3, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car4: Vehicle = Vehicle(4, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car5: Vehicle = Vehicle(5, mutableListOf(3, 4, 5, 8))
+        val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
+
+        val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        road.delayVehiclesInTimestep(allVehicles, 8)
+
+        var i: Int = 0
+        for (vehicle in allVehicles) {
+            if (vehicle.delayedInHours.contains(8)) {
+                i = i + 1
+            }
+        }
+        assertEquals(6, i)
+    }
+
+    @Test
+    fun delayVehiclesInTimestep_noVehiclesThere_notASingleDelay() {
+        val road = RoadNetwork(50)
+
+        val allVehicles: List<Vehicle> = listOf()
+
+        road.delayVehiclesInTimestep(allVehicles, 8)
+
+        var i: Int = 0
+        for (vehicle in allVehicles) {
+            if (vehicle.delayedInHours.contains(8)) {
+                i = i + 1
+            }
+        }
+        assertEquals(0, i)
+    }
+
+    @Test
     fun calculateDemandForTimestepAndCauseTrafficJam_RoadWithoutCapacity_everyDemandDelaysVehicle() {
         val road = RoadNetwork(0)
         val timestep = 8
@@ -144,10 +185,10 @@ class RoadNetworkTest {
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
 
-        road.calculateDemandForTimestepAndCauseTrafficJam(timestep , allVehicles)
+        road.calculateDemandForTimestepAndCauseTrafficJam(timestep, allVehicles)
 
-        for (vehicle in allVehicles){
-            val test : Boolean = vehicle.delayedInHours.contains(8)
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(8)
             assertEquals(true, test)
         }
     }
@@ -164,7 +205,7 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(24))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
         var i: Int = 0
 
@@ -185,7 +226,7 @@ class RoadNetworkTest {
         val car3: Vehicle = Vehicle(3, mutableListOf(19))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3)
-        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
         var i: Int = 0
 
@@ -209,7 +250,7 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
         var i: Int = 0
 
@@ -233,7 +274,7 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
         var i: Int = 0
 
@@ -255,11 +296,11 @@ class RoadNetworkTest {
         val car4: Vehicle = Vehicle(4, mutableListOf(3, 4, 5, 8, 9, 10, 11))
         val car5: Vehicle = Vehicle(5, mutableListOf(3, 4, 5, 8))
         val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
-        val car7: Vehicle = Vehicle(6, mutableListOf(9,10,11))
-        val car8: Vehicle = Vehicle(6, mutableListOf(9,10,11))
+        val car7: Vehicle = Vehicle(6, mutableListOf(9, 10, 11))
+        val car8: Vehicle = Vehicle(6, mutableListOf(9, 10, 11))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6, car7, car8)
-        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
         var i: Int = 0
 

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -4,42 +4,46 @@ import traffic_simulation.RoadNetwork
 import traffic_simulation.Vehicle
 
 class RoadNetworkTest {
-/*
+
     @Test
-    fun calculateDemand_DemandOfOneVehicle_demandIsTheVehiclesDemand() {
+    fun calculateDemandAtTimestep_DemandOfOneVehicleInFirstHour_demandIsTheVehiclesDemand() {
         val road = RoadNetwork(20)
 
-        val BMW: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8))
+        val BMW: Vehicle = Vehicle(1, mutableListOf(1, 4, 5, 8))
 
         val cars: List<Vehicle> = listOf(BMW)
 
-        val calculated = road.calculateDemandFor24Hours(cars)
+        val calculated = road.calculateDemandAtTimestep(cars , 1)
 
-        val correctMap: MutableMap<Int , Int> = mutableMapOf( Pair(1 , 0) , Pair(2 , 0) , Pair(3 , 1) , Pair(4 , 1) , Pair(5 , 1) ,
-                Pair(6 , 0) , Pair(7 , 0) , Pair(8 , 1) , Pair(9 , 0) , Pair(10 , 0) , Pair(11 , 0) , Pair(12 , 0) ,
-                Pair(13 , 0) , Pair(14 , 0) , Pair(15 , 0) , Pair(16 , 0) , Pair(17 , 0) , Pair(18 , 0) , Pair(19 , 0) ,
-                Pair(20 , 0) , Pair(21 , 0) , Pair(22 , 0) , Pair(23 , 0) , Pair(24 , 0) )
-
-        assertEquals(correctMap, calculated)
+        assertEquals(1, calculated)
     }
 
     @Test
-    fun calculateDemand_DemandOfNoneVehicle_thereIsNoDemand() {
+    fun calculateDemandAtTimestep_DemandOfOneVehicleInLastHour_demandIsTheVehiclesDemand() {
+        val road = RoadNetwork(20)
+
+        val BMW: Vehicle = Vehicle(1, mutableListOf(1, 4, 5, 8, 24))
+
+        val cars: List<Vehicle> = listOf(BMW)
+
+        val calculated = road.calculateDemandAtTimestep(cars , 24)
+
+        assertEquals(1, calculated)
+    }
+
+    @Test
+    fun calculateDemandAtTimestep_DemandOfNoneVehicle_thereIsNoDemand() {
         val road = RoadNetwork(20)
 
         val cars: List<Vehicle> = listOf()
 
-        val calculated = road.calculateDemandFor24Hours(cars)
+        val calculated = road.calculateDemandAtTimestep(cars , 5)
 
-        val correctMap: MutableMap<Int , Int> = mutableMapOf( Pair(1 , 0) , Pair(2 , 0) , Pair(3 , 0) , Pair(4 , 0) , Pair(5 , 0) ,
-                Pair(6 , 0) , Pair(7 , 0) , Pair(8 , 0) , Pair(9 , 0) , Pair(10 , 0) , Pair(11 , 0) , Pair(12 , 0) ,
-                Pair(13 , 0) , Pair(14 , 0) , Pair(15 , 0) , Pair(16 , 0) , Pair(17 , 0) , Pair(18 , 0) , Pair(19 , 0) ,
-                Pair(20 , 0) , Pair(21 , 0) , Pair(22 , 0) , Pair(23 , 0) , Pair(24 , 0) )
-        assertEquals(correctMap, calculated)
+        assertEquals(0, calculated)
     }
 
     @Test
-    fun calculateDemand_DemandOfSeveralVehicles_demandIsTheVehiclesDemand() {
+    fun calculateDemand_DemandOfSeveralVehicles_demandIsTheSummedVehiclesDemand() {
         val road = RoadNetwork(20)
 
         val BMW: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 24))
@@ -48,13 +52,24 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW, AUDI, VOLVO)
 
-        val calculated = road.calculateDemandFor24Hours(cars)
+        val calculated = road.calculateDemandAtTimestep(cars , 5)
 
-        val correctMap: MutableMap<Int , Int> = mutableMapOf( Pair(1 , 0) , Pair(2 , 0) , Pair(3 , 3) , Pair(4 , 3) , Pair(5 , 3) ,
-                Pair(6 , 0) , Pair(7 , 0) , Pair(8 , 3) , Pair(9 , 1) , Pair(10 , 1) , Pair(11 , 0) , Pair(12 , 0) ,
-                Pair(13 , 0) , Pair(14 , 0) , Pair(15 , 0) , Pair(16 , 0) , Pair(17 , 0) , Pair(18 , 0) , Pair(19 , 0) ,
-                Pair(20 , 0) , Pair(21 , 0) , Pair(22 , 0) , Pair(23 , 0) , Pair(24 , 1) )
-        assertEquals(correctMap, calculated)
+        assertEquals(3, calculated)
+    }
+
+    @Test
+    fun calculateDemand_DemandOfSeveralVehiclesNotInOrder_demandIsTheSummedVehiclesDemand() {
+        val road = RoadNetwork(20)
+
+        val BMW: Vehicle = Vehicle(1, mutableListOf(5, 8, 24, 3))
+        val AUDI: Vehicle = Vehicle(2, mutableListOf(8, 3, 4, 5, 9, 10))
+        val VOLVO: Vehicle = Vehicle(3, mutableListOf(8, 4, 3, 5, 8))
+
+        val cars: List<Vehicle> = listOf(BMW, AUDI, VOLVO)
+
+        val calculated = road.calculateDemandAtTimestep(cars , 5)
+
+        assertEquals(3, calculated)
     }
 
     @Test
@@ -67,59 +82,124 @@ class RoadNetworkTest {
 
         val cars: List<Vehicle> = listOf(BMW, AUDI, VOLVO)
 
-        val calculated = road.calculateDemandFor24Hours(cars)
+        val calculated = road.calculateDemandAtTimestep(cars, 24)
 
-        val correctMap: MutableMap<Int , Int> = mutableMapOf( Pair(1 , 0) , Pair(2 , 0) , Pair(3 , 0) , Pair(4 , 0) , Pair(5 , 0) ,
-                Pair(6 , 0) , Pair(7 , 0) , Pair(8 , 0) , Pair(9 , 0) , Pair(10 , 0) , Pair(11 , 0) , Pair(12 , 0) ,
-                Pair(13 , 0) , Pair(14 , 0) , Pair(15 , 0) , Pair(16 , 0) , Pair(17 , 0) , Pair(18 , 0) , Pair(19 , 0) ,
-                Pair(20 , 0) , Pair(21 , 0) , Pair(22 , 0) , Pair(23 , 0) , Pair(24 , 0) )
-        assertEquals(correctMap, calculated)
+        assertEquals(0, calculated)
     }
 
     @Test
-    fun doesCheckForTrafficJamWorkForCapacityBiggerThanDemand() {
+    fun isTrafficJam_capacityBiggerThanDemand_noTrafficJam() {
         val road = RoadNetwork(20)
 
-        val trafficJam: Boolean = road.checkForTrafficJamInSingleHour(mutableMapOf(Pair(3, 5)), 3)
+        val trafficJam: Boolean = road.isTrafficJam(3)
         assertEquals(false, trafficJam)
     }
 
     @Test
-    fun doesCheckForTrafficJamWorkForCapacitySmallerThanDemand() {
+    fun isTrafficJam_noCapacityCemand_noTrafficJam() {
+        val road = RoadNetwork(20)
+
+        val trafficJam: Boolean = road.isTrafficJam(0)
+        assertEquals(false, trafficJam)
+    }
+
+    @Test
+    fun isTrafficJam_capacitySmallerThanDemand_trafficJamdHappens() {
         val road = RoadNetwork(2)
 
-        val trafficJam: Boolean = road.checkForTrafficJamInSingleHour(mutableMapOf(Pair(3, 5)), 3)
+        val trafficJam: Boolean = road.isTrafficJam(3)
+
         assertEquals(true, trafficJam)
     }
 
     @Test
-    fun doesCheckForTrafficJamWorkForCapacityEqualToDemand() {
+    fun isTrafficJam_capacityEqualsDemand_noTrafficJam() {
         val road = RoadNetwork(5)
 
-        val trafficJam: Boolean = road.checkForTrafficJamInSingleHour(mutableMapOf(Pair(3, 5)), 3)
+        val trafficJam: Boolean = road.isTrafficJam(5)
+
         assertEquals(false, trafficJam)
     }
 
     @Test
-    fun roadNetworkWithZeroCapacityDelaysAlwaysCars() {
+    fun isTrafficJam_capacityAndDemandZero_noTrafficJam() {
         val road = RoadNetwork(0)
 
-        val trafficJam: Boolean = road.checkForTrafficJamInSingleHour(mutableMapOf(Pair(3, 5)), 3)
-        assertEquals(true, trafficJam)
-    }
+        val trafficJam: Boolean = road.isTrafficJam(0)
 
-    @Test
-    fun noTrafficJamIfNoCapacityNeedetDespideNoCapacityThere() {
-        val road = RoadNetwork(0)
-
-        val trafficJam: Boolean = road.checkForTrafficJamInSingleHour(mutableMapOf(Pair(3, 0)), 3)
         assertEquals(false, trafficJam)
     }
 
+    @Test
+    fun calculateDemandForTimestepAndCauseTrafficJam_RoadWithoutCapacity_everyDemandDelaysVehicle() {
+        val road = RoadNetwork(0)
+        val timestep = 8
+
+        val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car2: Vehicle = Vehicle(2, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car3: Vehicle = Vehicle(3, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car4: Vehicle = Vehicle(4, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car5: Vehicle = Vehicle(5, mutableListOf(3, 4, 5, 8))
+        val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
+
+        val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        road.calculateDemandForTimestepAndCauseTrafficJam(timestep , allVehicles)
+
+        for (vehicle in allVehicles){
+            val test : Boolean = vehicle.delayedInHours.contains(8)
+            assertEquals(true, test)
+        }
+    }
 
     @Test
-    fun simulateScenario_someVehiclesGettingDelayed_NumberOfDelaysIsCorrect() {
-        val road = RoadNetwork(5)
+    fun simulateScenario_vehiclesDemandTooMuchCapacityInLastTimestep_NumberOfDelaysIsCorrect() {
+        val road = RoadNetwork(2)
+
+        val car1: Vehicle = Vehicle(1, mutableListOf(24))
+        val car2: Vehicle = Vehicle(2, mutableListOf(24))
+        val car3: Vehicle = Vehicle(3, mutableListOf(24))
+        val car4: Vehicle = Vehicle(4, mutableListOf(24))
+        val car5: Vehicle = Vehicle(5, mutableListOf(24))
+        val car6: Vehicle = Vehicle(6, mutableListOf(24))
+
+        val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+
+        var i: Int = 0
+
+        for (car in output) {
+            for (hour in car.delayedInHours) {
+                i = i + 1
+            }
+        }
+        assertEquals(6, i)
+    }
+
+    @Test
+    fun simulateScenario_vehiclesDemandTooMuchCapacityInOneTimestep_delaysGoThroughAllTimestepsSinceThen() {
+        val road = RoadNetwork(2)
+
+        val car1: Vehicle = Vehicle(1, mutableListOf(19))
+        val car2: Vehicle = Vehicle(2, mutableListOf(19))
+        val car3: Vehicle = Vehicle(3, mutableListOf(19))
+
+        val allVehicles: List<Vehicle> = listOf(car1, car2, car3)
+        val output : List<Vehicle> = road.simulateScenario(allVehicles)
+
+        var i: Int = 0
+
+        for (car in output) {
+            for (hour in car.delayedInHours) {
+                i = i + 1
+            }
+        }
+        assertEquals(18, i)
+    }
+
+    @Test
+    fun simulateScenario_vehiclesDemandTooMuchCapacityInSeveralTimesteps_delaysGoThroughAllTimestepsSinceThen() {
+        val road = RoadNetwork(3)
 
         val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
         val car2: Vehicle = Vehicle(2, mutableListOf(3, 4, 5, 8, 9, 10, 11))
@@ -138,7 +218,7 @@ class RoadNetworkTest {
                 i = i + 1
             }
         }
-        assertEquals(24, i)
+        assertEquals(132, i)
     }
 
     @Test
@@ -190,5 +270,4 @@ class RoadNetworkTest {
         }
         assertEquals(0, i)
     }
-    */
 }

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -146,7 +146,7 @@ class RoadNetworkTest {
         road.delayVehiclesInTimestep(allVehicles, 8)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(8)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(8)
             assertEquals(true, test)
         }
 
@@ -168,37 +168,37 @@ class RoadNetworkTest {
         road.delayVehiclesInTimestep(allVehicles, 8)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(8)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(8)
             assertEquals(true, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(3)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(3)
             assertEquals(false, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(4)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(4)
             assertEquals(false, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(5)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(5)
             assertEquals(false, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(9)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(9)
             assertEquals(false, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(10)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(10)
             assertEquals(false, test)
         }
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(11)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(11)
             assertEquals(false, test)
         }
 
@@ -213,7 +213,7 @@ class RoadNetworkTest {
         road.delayVehiclesInTimestep(allVehicles, 8)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(8)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(8)
             assertEquals(false, test)
         }
     }
@@ -235,7 +235,7 @@ class RoadNetworkTest {
         road.calculateDemandForTimestepAndCauseTrafficJam(timestep, allVehicles)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(8)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(8)
             assertEquals(true, test)
         }
     }
@@ -256,7 +256,7 @@ class RoadNetworkTest {
         road.simulateScenario(allVehicles)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = vehicle.delayedInHours.contains(24)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(24)
             assertEquals(true, test)
         }
     }
@@ -275,13 +275,13 @@ class RoadNetworkTest {
 
         for (vehicle in allVehicles) {
             for (timestep in 1..18){
-                val test : Boolean = vehicle.delayedInHours.contains(timestep)
+                val test : Boolean = vehicle.gotNewDelayInHours.contains(timestep)
                 assertEquals(false , test)
             }
-            val test: Boolean = vehicle.delayedInHours.contains(19)
+            val test: Boolean = vehicle.gotNewDelayInHours.contains(19)
             assertEquals(true, test)
             for (timestep in 20..24){
-                val test : Boolean = vehicle.delayedInHours.contains(timestep)
+                val test : Boolean = vehicle.gotNewDelayInHours.contains(timestep)
                 assertEquals(false, test)
             }
         }
@@ -325,7 +325,7 @@ class RoadNetworkTest {
         for (timestep in 1..24) {
 
             for (vehicle in allVehicles) {
-                val test: Boolean = (vehicle.delayedInHours.contains(timestep))
+                val test: Boolean = (vehicle.gotNewDelayInHours.contains(timestep))
                 assertEquals(false, test)
             }
         }
@@ -351,7 +351,7 @@ class RoadNetworkTest {
         for (timestep in 1..24) {
 
             for (vehicle in allVehicles) {
-                val test: Boolean = (vehicle.delayedInHours.contains(timestep))
+                val test: Boolean = (vehicle.gotNewDelayInHours.contains(timestep))
                 assertEquals(false, test)
             }
         }

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -235,7 +235,7 @@ class RoadNetworkTest {
                 i = i + 1
             }
         }
-        assertEquals(18, i)
+        assertEquals(3, i)
     }
 
     @Test
@@ -259,7 +259,7 @@ class RoadNetworkTest {
                 i = i + 1
             }
         }
-        assertEquals(132, i)
+        assertEquals(36, i)
     }
 
     @Test

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -145,13 +145,63 @@ class RoadNetworkTest {
 
         road.delayVehiclesInTimestep(allVehicles, 8)
 
-        var i: Int = 0
         for (vehicle in allVehicles) {
-            if (vehicle.delayedInHours.contains(8)) {
-                i = i + 1
-            }
+            val test: Boolean = vehicle.delayedInHours.contains(8)
+            assertEquals(true, test)
         }
-        assertEquals(6, i)
+
+    }
+
+    @Test
+    fun delayVehiclesInTimestep_someVehiclesThere_delayedInHoursContainsOnlyTimestepWithTrafficJam() {
+        val road = RoadNetwork(0)
+
+        val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car2: Vehicle = Vehicle(2, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car3: Vehicle = Vehicle(3, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car4: Vehicle = Vehicle(4, mutableListOf(3, 4, 5, 8, 9, 10, 11))
+        val car5: Vehicle = Vehicle(5, mutableListOf(3, 4, 5, 8))
+        val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
+
+        val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
+
+        road.delayVehiclesInTimestep(allVehicles, 8)
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(8)
+            assertEquals(true, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(3)
+            assertEquals(false, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(4)
+            assertEquals(false, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(5)
+            assertEquals(false, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(9)
+            assertEquals(false, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(10)
+            assertEquals(false, test)
+        }
+
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(11)
+            assertEquals(false, test)
+        }
+
     }
 
     @Test
@@ -162,13 +212,10 @@ class RoadNetworkTest {
 
         road.delayVehiclesInTimestep(allVehicles, 8)
 
-        var i: Int = 0
         for (vehicle in allVehicles) {
-            if (vehicle.delayedInHours.contains(8)) {
-                i = i + 1
-            }
+            val test: Boolean = vehicle.delayedInHours.contains(8)
+            assertEquals(false, test)
         }
-        assertEquals(0, i)
     }
 
     @Test
@@ -205,20 +252,17 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(24))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
-        var i: Int = 0
+        road.simulateScenario(allVehicles)
 
-        for (car in output) {
-            for (hour in car.delayedInHours) {
-                i = i + 1
-            }
+        for (vehicle in allVehicles) {
+            val test: Boolean = vehicle.delayedInHours.contains(24)
+            assertEquals(true, test)
         }
-        assertEquals(6, i)
     }
 
     @Test
-    fun simulateScenario_vehiclesDemandTooMuchCapacityInOneTimestep_delaysGoThroughAllTimestepsSinceThen() {
+    fun simulateScenario_vehiclesDemandTooMuchCapacityInOneTimestep_newDelaysJustInThisTimestep() {
         val road = RoadNetwork(2)
 
         val car1: Vehicle = Vehicle(1, mutableListOf(19))
@@ -226,20 +270,25 @@ class RoadNetworkTest {
         val car3: Vehicle = Vehicle(3, mutableListOf(19))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3)
-        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
-        var i: Int = 0
+        road.simulateScenario(allVehicles)
 
-        for (car in output) {
-            for (hour in car.delayedInHours) {
-                i = i + 1
+        for (vehicle in allVehicles) {
+            for (timestep in 1..18){
+                val test : Boolean = vehicle.delayedInHours.contains(timestep)
+                assertEquals(false , test)
+            }
+            val test: Boolean = vehicle.delayedInHours.contains(19)
+            assertEquals(true, test)
+            for (timestep in 20..24){
+                val test : Boolean = vehicle.delayedInHours.contains(timestep)
+                assertEquals(false, test)
             }
         }
-        assertEquals(3, i)
     }
 
     @Test
-    fun simulateScenario_vehiclesDemandTooMuchCapacityInSeveralTimesteps_delaysGoThroughAllTimestepsSinceThen() {
+    fun simulateScenario_vehiclesDemandTooMuchCapacityInSeveralTimesteps_vehiclesDalyGoThroughAllTimestepsSinceThen() {
         val road = RoadNetwork(3)
 
         val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
@@ -250,20 +299,17 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output: List<Vehicle> = road.simulateScenario(allVehicles)
 
-        var i: Int = 0
+        road.simulateScenario(allVehicles)
 
-        for (car in output) {
-            for (hour in car.delayedInHours) {
-                i = i + 1
-            }
+        for (vehicle in allVehicles) {
+            val test: Boolean = ( vehicle.delay > 0 )
+            assertEquals(true, test)
         }
-        assertEquals(36, i)
     }
 
     @Test
-    fun simulateScenario_noVehiclesGettingDelayed_NumberOfDelaysIsCorrect() {
+    fun simulateScenario_networksCapacityAlwaysHigherDemand_notASingleDelay() {
         val road = RoadNetwork(50)
 
         val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
@@ -274,20 +320,20 @@ class RoadNetworkTest {
         val car6: Vehicle = Vehicle(6, mutableListOf(3, 4, 5, 8))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6)
-        val output: List<Vehicle> = road.simulateScenario(allVehicles)
+        road.simulateScenario(allVehicles)
 
-        var i: Int = 0
+        for (timestep in 1..24) {
 
-        for (car in output) {
-            for (hour in car.delayedInHours) {
-                i = i + 1
+            for (vehicle in allVehicles) {
+                val test: Boolean = (vehicle.delayedInHours.contains(timestep))
+                assertEquals(false, test)
             }
         }
-        assertEquals(0, i)
+
     }
 
     @Test
-    fun simulateScenario_demandMatchesCapacity_noDelays() {
+    fun simulateScenario_demandMatchesCapacity_notASingleDelay() {
         val road = RoadNetwork(6)
 
         val car1: Vehicle = Vehicle(1, mutableListOf(3, 4, 5, 8, 9, 10, 11))
@@ -300,15 +346,14 @@ class RoadNetworkTest {
         val car8: Vehicle = Vehicle(6, mutableListOf(9, 10, 11))
 
         val allVehicles: List<Vehicle> = listOf(car1, car2, car3, car4, car5, car6, car7, car8)
-        val output: List<Vehicle> = road.simulateScenario(allVehicles)
+        road.simulateScenario(allVehicles)
 
-        var i: Int = 0
+        for (timestep in 1..24) {
 
-        for (car in output) {
-            for (hour in car.delayedInHours) {
-                i = i + 1
+            for (vehicle in allVehicles) {
+                val test: Boolean = (vehicle.delayedInHours.contains(timestep))
+                assertEquals(false, test)
             }
         }
-        assertEquals(0, i)
     }
 }

--- a/src/test/kotlin/VehicleTest.kt
+++ b/src/test/kotlin/VehicleTest.kt
@@ -58,4 +58,51 @@ class VehicleTest {
 
         assertEquals(correctList, BMW.delayedInHours)
     }
+
+    @Test
+    fun delayAndDrive_mixedDelaysAndDriveRequirements_driveRequirementsCorrectlyReported() {
+        val tesla = Vehicle(1, mutableListOf(1, 5))
+        assertTrue(tesla.vehicleWantsToDriveAt(1))
+
+        tesla.getDelayedAtHour(1)
+        // couldn't drive at 1, so wants to drive at 2
+        assertTrue(tesla.vehicleWantsToDriveAt(2))
+
+        tesla.getDelayedAtHour(2)
+        // again, couldn't drive,  so wants to drive at 3
+        assertTrue(tesla.vehicleWantsToDriveAt(3))
+
+        tesla.driveAtHour(3)
+        // finally time to drive; this resolves delay from hour 1, so no more driving
+        assertFalse(tesla.vehicleWantsToDriveAt(4))
+
+        // wants to drive at hour 5 as per original requirements
+        assertTrue(tesla.vehicleWantsToDriveAt(5))
+    }
+
+    @Test
+    fun delayAndDrive_mixedDelaysAndDriveRequirements_driveRequirementsCarriedAcross() {
+        val tesla = Vehicle(1, mutableListOf(1, 2, 4))
+        assertTrue(tesla.vehicleWantsToDriveAt(1))
+
+        tesla.getDelayedAtHour(1)
+        // couldn't drive at 1 _and_ wanted to drive at 2 anyways
+        assertTrue(tesla.vehicleWantsToDriveAt(2))
+
+        tesla.getDelayedAtHour(2)
+        // couldn't drive at 1 & 2, so definitely wants to drive at 3
+        assertTrue(tesla.vehicleWantsToDriveAt(3))
+
+        tesla.driveAtHour(3)
+        // still one hour delayed _and_ wants to drive at 4 anyways
+        assertTrue(tesla.vehicleWantsToDriveAt(4))
+
+        tesla.driveAtHour(4)
+        // driving at 4 accomplished but still one hour delayed, so wants to drive again
+        assertTrue(tesla.vehicleWantsToDriveAt(5))
+
+        tesla.driveAtHour(5)
+        // finally all done
+        assertFalse(tesla.vehicleWantsToDriveAt(6))
+    }
 }

--- a/src/test/kotlin/VehicleTest.kt
+++ b/src/test/kotlin/VehicleTest.kt
@@ -13,7 +13,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(1)
 
         val correctList : MutableList <Int> = mutableListOf(1)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -26,7 +26,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(5)
 
         val correctList : MutableList <Int> = mutableListOf(1,3,4,5)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -36,7 +36,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(24)
 
         val correctList : MutableList <Int> = mutableListOf(24)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -49,7 +49,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(4)
 
         val correctList : MutableList <Int> = mutableListOf(1,3,4,5)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -58,7 +58,7 @@ class VehicleTest {
 
         val correctList : MutableList <Int> = mutableListOf()
 
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test

--- a/src/test/kotlin/VehicleTest.kt
+++ b/src/test/kotlin/VehicleTest.kt
@@ -1,5 +1,7 @@
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
 import traffic_simulation.Vehicle
 
 class VehicleTest {


### PR DESCRIPTION
Beginn der Lösung für Issue #82 
Closes #82 

Es wurden Tests für RoadNetwork geschrieben. Für die Tests wurde die Funktion `calculateDemandAtTimestep` zunächst noch in mehrere neue Unterfunktionen heruntergebrochen.

Bei der Erstellung der Tests ist aufgefallen, dass der Impact auf die wannaDrive-Liste bei einer Verspätung nicht erfolgt. Dies wird mit diesem PullRequest gelößt, der Impact wurde eingefügt.