### PR TITLE
Output erweitert um planmäßiges Fahren

### DIFF
--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -38,7 +38,8 @@ fun testScenarioWithInternList() {
     val testList: List<Vehicle> = listOf(BMW1, BMW2, BMW3, BMW4, BMW5, BMW6, BMW7, BMW8, BMW9, BMW10, BMW11, BMW12)
 
     for (vehicle in road.simulateScenario(testList)) {
-        println("Vehicle '${vehicle.id}' is delayed: ${vehicle.delayedInHours}")
+        println("Vehicle '${vehicle.id}' is delayed in hours: ${vehicle.delayedInHours} " +
+                "drove without delays in hours: ${vehicle.droveWithoutDelayInHours}")
     }
 }
 
@@ -95,13 +96,15 @@ fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv"
         val vehicleRows: MutableList<Array<Any>> = mutableListOf()
         val id = "VehicleID"
         val delay = "Delayed in hours"
-        val row: Array<Any> = arrayOf(id, delay)
+        val notDelay = "Driven without delay in hours"
+        val row: Array<Any> = arrayOf(id, delay, notDelay)
         vehicleRows.add(row)
 
         for (result in results) {
             val id = result.id.toString()
             val delay = result.delayedInHours.toString()
-            val row: Array<Any> = arrayOf(id, delay)
+            val notDelay = result.droveWithoutDelayInHours.toString()
+            val row: Array<Any> = arrayOf(id, delay, notDelay)
             vehicleRows.add(row)
         }
         csvWriter.writeRowsAndClose(vehicleRows)

--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -95,8 +95,8 @@ fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv"
     // Write the record headers of this file
     val vehicleRows: MutableList<Array<Any>> = mutableListOf()
     val id = "VehicleID"
-    val delay = "Delayed in hours"
-    val notDelay = "Driven without delay in hours"
+    val delay = "Got a new delay in hours because of traffic jam"
+    val notDelay = "Driven without a new delay in hours (no traffic jam)"
     val row: Array<Any> = arrayOf(id, delay, notDelay)
     vehicleRows.add(row)
 

--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -38,8 +38,8 @@ fun testScenarioWithInternList() {
     val testList: List<Vehicle> = listOf(BMW1, BMW2, BMW3, BMW4, BMW5, BMW6, BMW7, BMW8, BMW9, BMW10, BMW11, BMW12)
 
     for (vehicle in road.simulateScenario(testList)) {
-        println("Vehicle '${vehicle.id}' is delayed in hours: ${vehicle.delayedInHours} " +
-                "drove without delays in hours: ${vehicle.droveWithoutDelayInHours}")
+        println("Vehicle '${vehicle.id}' got a delay cause of traffic jam in hours: ${vehicle.delayedInHours} " +
+                "drove without new delays in hours (no traffic jam): ${vehicle.droveWithoutNewDelayInHours}")
     }
 }
 
@@ -103,7 +103,7 @@ fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv"
     for (result in results) {
         val id = result.id.toString()
         val delay = result.delayedInHours.toString()
-        val notDelay = result.droveWithoutDelayInHours.toString()
+        val notDelay = result.droveWithoutNewDelayInHours.toString()
         val row: Array<Any> = arrayOf(id, delay, notDelay)
         vehicleRows.add(row)
     }

--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -45,74 +45,74 @@ fun testScenarioWithInternList() {
 
 
 fun parseInputOfCSV(fileName: String): MutableList<Vehicle> {
-        val vehicleListCSV: MutableList<Vehicle> = mutableListOf()
+    val vehicleListCSV: MutableList<Vehicle> = mutableListOf()
 
-        // The information of vehicles and their interest to drive is given in a csv-file
-        // Therefore we use a library to parse
-        // Setup of the parsing like symbol of separation etc.
-        // in this case mostly the default settings so just a few things have to be set
-        val settings = CsvParserSettings()
-        settings.format.setLineSeparator("\n")
-        settings.isHeaderExtractionEnabled = true
-        // this is to make the parser ignoring the first line in the csv-file
+    // The information of vehicles and their interest to drive is given in a csv-file
+    // Therefore we use a library to parse
+    // Setup of the parsing like symbol of separation etc.
+    // in this case mostly the default settings so just a few things have to be set
+    val settings = CsvParserSettings()
+    settings.format.setLineSeparator("\n")
+    settings.isHeaderExtractionEnabled = true
+    // this is to make the parser ignoring the first line in the csv-file
 
-        // creating a parser with the former made settings
-        val csvParser = CsvParser(settings)
+    // creating a parser with the former made settings
+    val csvParser = CsvParser(settings)
 
-        // reading of the csv-file
-        val reader = FileAccess().getReader("/" + fileName)
+    // reading of the csv-file
+    val reader = FileAccess().getReader("/" + fileName)
 
-        // analyze (parse) of the csv given
-        val allRows: MutableList<Record> = csvParser.parseAllRecords(reader)
+    // analyze (parse) of the csv given
+    val allRows: MutableList<Record> = csvParser.parseAllRecords(reader)
 
-        // insert the parsed information of csv-file in usable lists and use them in functions
-        for (record in allRows) {
-            val id_String: String = record.values[0]
-            val wannaDrive_String: String = record.values[1]
+    // insert the parsed information of csv-file in usable lists and use them in functions
+    for (record in allRows) {
+        val id_String: String = record.values[0]
+        val wannaDrive_String: String = record.values[1]
 
-            val id_Int: Int = id_String.toInt()
-            val wannaDrive_List: MutableList<Int> = mutableListOf()
+        val id_Int: Int = id_String.toInt()
+        val wannaDrive_List: MutableList<Int> = mutableListOf()
 
-            val separator: Char = '/'
-            val splittedWannaDrive: List<String> = wannaDrive_String.split(separator)
+        val separator: Char = '/'
+        val splittedWannaDrive: List<String> = wannaDrive_String.split(separator)
 
-            for (hour in splittedWannaDrive) {
-                val newHour_Int: Int = hour.toInt()
-                wannaDrive_List.add(newHour_Int)
-            }
-
-            wannaDrive_List.sort()
-            vehicleListCSV.add(Vehicle(id = id_Int, wannaDriveInHours = wannaDrive_List))
+        for (hour in splittedWannaDrive) {
+            val newHour_Int: Int = hour.toInt()
+            wannaDrive_List.add(newHour_Int)
         }
-        return vehicleListCSV
+
+        wannaDrive_List.sort()
+        vehicleListCSV.add(Vehicle(id = id_Int, wannaDriveInHours = wannaDrive_List))
     }
+    return vehicleListCSV
+}
 
 fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv") {
-        val writer = FileAccess().getWriter(outputFile)
+    val writer = FileAccess().getWriter(outputFile)
 
-        val csvWriter = CsvWriter(writer, CsvWriterSettings())
+    val csvWriter = CsvWriter(writer, CsvWriterSettings())
 
-        // Write the record headers of this file
-        val vehicleRows: MutableList<Array<Any>> = mutableListOf()
-        val id = "VehicleID"
-        val delay = "Delayed in hours"
-        val notDelay = "Driven without delay in hours"
+    // Write the record headers of this file
+    val vehicleRows: MutableList<Array<Any>> = mutableListOf()
+    val id = "VehicleID"
+    val delay = "Delayed in hours"
+    val notDelay = "Driven without delay in hours"
+    val row: Array<Any> = arrayOf(id, delay, notDelay)
+    vehicleRows.add(row)
+
+    for (result in results) {
+        val id = result.id.toString()
+        val delay = result.delayedInHours.toString()
+        val notDelay = result.droveWithoutDelayInHours.toString()
         val row: Array<Any> = arrayOf(id, delay, notDelay)
         vehicleRows.add(row)
-
-        for (result in results) {
-            val id = result.id.toString()
-            val delay = result.delayedInHours.toString()
-            val notDelay = result.droveWithoutDelayInHours.toString()
-            val row: Array<Any> = arrayOf(id, delay, notDelay)
-            vehicleRows.add(row)
-        }
-        csvWriter.writeRowsAndClose(vehicleRows)
     }
+    csvWriter.writeRowsAndClose(vehicleRows)
+}
 
 fun simulateCSV() {
-        val road: RoadNetwork = RoadNetwork(capacity = 10)
-        val vehiclesFromCSV: List<Vehicle> = parseInputOfCSV(fileName = "driveInterest.csv")
+    val road: RoadNetwork = RoadNetwork(capacity = 10)
+    val vehiclesFromCSV: List<Vehicle> = parseInputOfCSV(fileName = "driveInterest.csv")
 
-        printResultsToCSV(road.simulateScenario(vehiclesFromCSV))
-    }
+    printResultsToCSV(road.simulateScenario(vehiclesFromCSV))
+}

--- a/src/main/kotlin/traffic_simulation/Main.kt
+++ b/src/main/kotlin/traffic_simulation/Main.kt
@@ -38,7 +38,7 @@ fun testScenarioWithInternList() {
     val testList: List<Vehicle> = listOf(BMW1, BMW2, BMW3, BMW4, BMW5, BMW6, BMW7, BMW8, BMW9, BMW10, BMW11, BMW12)
 
     for (vehicle in road.simulateScenario(testList)) {
-        println("Vehicle '${vehicle.id}' got a delay cause of traffic jam in hours: ${vehicle.delayedInHours} " +
+        println("Vehicle '${vehicle.id}' got a delay cause of traffic jam in hours: ${vehicle.gotNewDelayInHours} " +
                 "drove without new delays in hours (no traffic jam): ${vehicle.droveWithoutNewDelayInHours}")
     }
 }
@@ -102,7 +102,7 @@ fun printResultsToCSV(results: List<Vehicle>, outputFile: String = "results.csv"
 
     for (result in results) {
         val id = result.id.toString()
-        val delay = result.delayedInHours.toString()
+        val delay = result.gotNewDelayInHours.toString()
         val notDelay = result.droveWithoutNewDelayInHours.toString()
         val row: Array<Any> = arrayOf(id, delay, notDelay)
         vehicleRows.add(row)

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -29,9 +29,7 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
             delay -= 1
         }
 
-        if (delay <= 0 && wannaDriveInHours.contains(timestep)){
-            droveWithoutNewDelayInHours.add(timestep)
-        }
+        droveWithoutNewDelayInHours.add(timestep)
     }
 
 }

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -2,7 +2,7 @@ package traffic_simulation
 
 class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
 
-    val delayedInHours : MutableList<Int> = mutableListOf()
+    val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
     var delay = 0
 
@@ -17,8 +17,8 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
         // (otherwise it just waited an hour, not reducing its delay)
         if (wannaDriveInHours.contains(timestep)) {
             delay += 1
-            this.delayedInHours.add(timestep)
-            this.delayedInHours.sort()
+            this.gotNewDelayInHours.add(timestep)
+            this.gotNewDelayInHours.sort()
         }
     }
 

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -29,7 +29,9 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
             delay -= 1
         }
 
-        droveWithoutNewDelayInHours.add(timestep)
+        this.droveWithoutNewDelayInHours.add(timestep)
+        this.droveWithoutNewDelayInHours.sort()
+
     }
 
 }

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -3,6 +3,7 @@ package traffic_simulation
 class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
 
     val delayedInHours : MutableList<Int> = mutableListOf()
+    val droveWithoutDelayInHours : MutableList<Int> = mutableListOf()
     var delay = 0
 
     fun vehicleWantsToDriveAt(timestep :Int):Boolean{
@@ -26,6 +27,10 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
         // (otherwise it just gained an hour, thus reducing delay)
         if (!wannaDriveInHours.contains(timestep)) {
             delay -= 1
+        }
+
+        if (delay <= 0 && wannaDriveInHours.contains(timestep)){
+            droveWithoutDelayInHours.add(timestep)
         }
     }
 

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -3,7 +3,7 @@ package traffic_simulation
 class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
 
     val delayedInHours : MutableList<Int> = mutableListOf()
-    val droveWithoutDelayInHours : MutableList<Int> = mutableListOf()
+    val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
     var delay = 0
 
     fun vehicleWantsToDriveAt(timestep :Int):Boolean{
@@ -30,7 +30,7 @@ class Vehicle(val id: Int, val wannaDriveInHours: MutableList<Int>) {
         }
 
         if (delay <= 0 && wannaDriveInHours.contains(timestep)){
-            droveWithoutDelayInHours.add(timestep)
+            droveWithoutNewDelayInHours.add(timestep)
         }
     }
 

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -134,7 +134,7 @@ class RoadNetworkTest {
         var i: Int = 0
 
         for (car in output) {
-            for (hour in car.delayedInHours) {
+            for (hour in car.gotNewDelayInHours) {
                 i = i + 1
             }
         }
@@ -158,7 +158,7 @@ class RoadNetworkTest {
         var i: Int = 0
 
         for (car in output) {
-            for (hour in car.delayedInHours) {
+            for (hour in car.gotNewDelayInHours) {
                 i = i + 1
             }
         }
@@ -184,7 +184,7 @@ class RoadNetworkTest {
         var i: Int = 0
 
         for (car in output) {
-            for (hour in car.delayedInHours) {
+            for (hour in car.gotNewDelayInHours) {
                 i = i + 1
             }
         }

--- a/src/test/kotlin/VehicleTest.kt
+++ b/src/test/kotlin/VehicleTest.kt
@@ -11,7 +11,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(1)
 
         val correctList : MutableList <Int> = mutableListOf(1)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -24,7 +24,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(5)
 
         val correctList : MutableList <Int> = mutableListOf(1,3,4,5)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -34,7 +34,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(24)
 
         val correctList : MutableList <Int> = mutableListOf(24)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -47,7 +47,7 @@ class VehicleTest {
         BMW.getDelayedAtHour(4)
 
         val correctList : MutableList <Int> = mutableListOf(1,3,4,5)
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 
     @Test
@@ -56,6 +56,6 @@ class VehicleTest {
 
         val correctList : MutableList <Int> = mutableListOf()
 
-        assertEquals(correctList, BMW.delayedInHours)
+        assertEquals(correctList, BMW.gotNewDelayInHours)
     }
 }


### PR DESCRIPTION
Lösung für Issue #84 
Closes #84 

Wie in der Issue beschrieben fehlte noch die Information, wann das Vehicle planmäßig - nicht delayed - fahren konnte. Habe dazu eine Liste erstellt und sie beim CSV-Output wie auch dem Output des internen Testszenarios angefügt.

Die Änderungen erscheinen wesentlich mehr als sie es wirklich waren. Der zweite Commit ist ganz alleine nur Reformat Code, die eigentlichen Änderungen sind im ersten Commit.