### PR TITLE
Änderungen der Wahrscheinlikeiten der delays

### DIFF
--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -123,22 +123,22 @@ class Tram(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     }
 
     override fun randomDelayByCapacityAndDemand(demandX: Int, capacity: Int): Boolean {
-        var probabilityOfDelay: Int = 0
+        var probabilityOfDelayInTwoHundred: Int = 0
         val percentOfCapacityUsage_Double: Double = (demandX.toDouble() / capacity.toDouble()) * 100
         val percentOfCapacityUsage: Int = percentOfCapacityUsage_Double.toInt()
         when (percentOfCapacityUsage) {
-            in 0..49 -> probabilityOfDelay = 5
-            in 50..69 -> probabilityOfDelay = 10
-            in 70..89 -> probabilityOfDelay = 20
-            in 90..109 -> probabilityOfDelay = 30
-            in 110..124 -> probabilityOfDelay = 50
-            in 125..149 -> probabilityOfDelay = 70
-            in 150..Int.MAX_VALUE -> probabilityOfDelay = 90
+            in 0..49 -> probabilityOfDelayInTwoHundred = 5
+            in 50..69 -> probabilityOfDelayInTwoHundred = 10
+            in 70..89 -> probabilityOfDelayInTwoHundred = 20
+            in 90..109 -> probabilityOfDelayInTwoHundred = 30
+            in 110..124 -> probabilityOfDelayInTwoHundred = 50
+            in 125..149 -> probabilityOfDelayInTwoHundred = 70
+            in 150..Int.MAX_VALUE -> probabilityOfDelayInTwoHundred = 90
         }
         if (capacity == 0) {
-            probabilityOfDelay = 100
+            probabilityOfDelayInTwoHundred = 200
         }
-        val delayed: Boolean = Random().nextInt(100) + 1 <= probabilityOfDelay
+        val delayed: Boolean = Random().nextInt(200) + 1 <= probabilityOfDelayInTwoHundred
         return delayed
     }
 
@@ -191,13 +191,13 @@ class Truck(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
         val percentOfCapacityUsage_Double: Double = (demandX.toDouble() / capacity.toDouble()) * 100
         val percentOfCapacityUsage: Int = percentOfCapacityUsage_Double.toInt()
         when (percentOfCapacityUsage) {
-            in 0..49 -> probabilityOfDelay = 5
-            in 50..69 -> probabilityOfDelay = 10
-            in 70..89 -> probabilityOfDelay = 20
-            in 90..109 -> probabilityOfDelay = 30
-            in 110..124 -> probabilityOfDelay = 50
-            in 125..149 -> probabilityOfDelay = 70
-            in 150..Int.MAX_VALUE -> probabilityOfDelay = 90
+            in 0..49 -> probabilityOfDelay = 10
+            in 50..69 -> probabilityOfDelay = 15
+            in 70..89 -> probabilityOfDelay = 25
+            in 90..109 -> probabilityOfDelay = 35
+            in 110..124 -> probabilityOfDelay = 55
+            in 125..149 -> probabilityOfDelay = 75
+            in 150..Int.MAX_VALUE -> probabilityOfDelay = 95
         }
         if (capacity == 0) {
             probabilityOfDelay = 100
@@ -255,13 +255,8 @@ class Bike(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
         val percentOfCapacityUsage_Double: Double = (demandX.toDouble() / capacity.toDouble()) * 100
         val percentOfCapacityUsage: Int = percentOfCapacityUsage_Double.toInt()
         when (percentOfCapacityUsage) {
-            in 0..49 -> probabilityOfDelay = 5
-            in 50..69 -> probabilityOfDelay = 10
-            in 70..89 -> probabilityOfDelay = 20
-            in 90..109 -> probabilityOfDelay = 30
-            in 110..124 -> probabilityOfDelay = 50
-            in 125..149 -> probabilityOfDelay = 70
-            in 150..Int.MAX_VALUE -> probabilityOfDelay = 90
+            in 0..149 -> probabilityOfDelay = 5
+            in 150..Int.MAX_VALUE -> probabilityOfDelay = 10
         }
         if (capacity == 0) {
             probabilityOfDelay = 100


### PR DESCRIPTION
Lösungvorschlag Issue #90 
Closes #90 

Habe die Funktion einzelnen `randomDelayByCapacityAndDemand`-Funktoinen des Interface Vehicle afu die verschiedenen Verspätungs-Wahrscheinlichkeiten angepasst. Damit bei `Tram` Kommazahlen vermieden werden habe ich bei dieser die Spanne der Zufallszahlen auf 200 erhöht. 