### PR TITLE
Vehicle-Interface reduziert

### DIFF
--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -6,7 +6,6 @@ interface Vehicle {
 
     val gotNewDelayInHours: MutableList<Int>
     val droveWithoutNewDelayInHours: MutableList<Int>
-    var delay: Int
 
     fun getClass(): String
     fun getID(): Int
@@ -20,7 +19,7 @@ class Car(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    override var delay = 0
+    var delay = 0
 
     override fun getClass(): String {
         return "Car"
@@ -84,7 +83,7 @@ class Tram(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    override var delay = 0
+    var delay = 0
 
     override fun getClass(): String {
         return "Tram"
@@ -148,7 +147,7 @@ class Truck(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    override var delay = 0
+    var delay = 0
 
     override fun getClass(): String {
         return "Truck"
@@ -212,7 +211,7 @@ class Bike(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    override var delay = 0
+    var delay = 0
 
     override fun getClass(): String {
         return "Bike"

--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -4,8 +4,8 @@ import java.util.*
 
 interface Vehicle {
 
-    val gotNewDelayInHours: MutableList<Int>
-    val droveWithoutNewDelayInHours: MutableList<Int>
+    val gotNewDelayInHours: List<Int>
+    val droveWithoutNewDelayInHours: List<Int>
 
     fun getClass(): String
     fun getID(): Int


### PR DESCRIPTION
Lösung für Issue #100 
Closes #100 

Aus dem Interface `Vehicle` wurde der Wert `delay` entfernt. Dadurch soll das `RoadNetwork` nicht mehr in der Lage sein, ohne Beteiligung von den Funktionen der Klasse `Vehicle`, den Zustand von `delay` zu verändern. 

Aus dem gleichen Grund sind zwei Listen des Interface `Vehicle` von `MutableList<Int>` zu `List<Int>` geworden. In der Unterklassen des Interface `Vehicle` blieben die Listen mutable.