### PR TITLE
delay umbenannt zu lagTillDestination

### DIFF
--- a/src/main/kotlin/traffic_simulation/Vehicle.kt
+++ b/src/main/kotlin/traffic_simulation/Vehicle.kt
@@ -22,7 +22,7 @@ class Car(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override val capacityFactor = 10
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    var delay = 0
+    var lagTillDestination = 0
 
     override fun getClass(): String {
         return "Car"
@@ -35,14 +35,14 @@ class Car(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override fun vehicleWantsToDriveAt(timestep: Int): Boolean {
         // the vehicle wants to drive if its drive plan says so
         // or if it got previously delayed
-        return wannaDriveInHours.contains(timestep) || delay > 0
+        return wannaDriveInHours.contains(timestep) || lagTillDestination > 0
     }
 
     override fun getDelayedAtHour(timestep: Int) {
-        // if the vehicle wanted to drive, its delay increased
-        // (otherwise it just waited an hour, not reducing its delay)
+        // if the vehicle wanted to drive, its lagTillDestination increased
+        // (otherwise it just waited an hour, not reducing its lagTillDestination)
         if (wannaDriveInHours.contains(timestep)) {
-            delay += 1
+            lagTillDestination += 1
             this.gotNewDelayInHours.add(timestep)
             this.gotNewDelayInHours.sort()
         }
@@ -50,9 +50,9 @@ class Car(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override fun driveAtHour(timestep: Int) {
         // if the vehicle wanted to drive, it is still as delayed as before
-        // (otherwise it just gained an hour, thus reducing delay)
+        // (otherwise it just gained an hour, thus reducing lagTillDestination)
         if (!wannaDriveInHours.contains(timestep)) {
-            delay -= 1
+            lagTillDestination -= 1
         }
 
         this.droveWithoutNewDelayInHours.add(timestep)
@@ -85,7 +85,7 @@ class Tram(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override val capacityFactor = 50
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    var delay = 0
+    var lagTillDestination = 0
 
     override fun getClass(): String {
         return "Tram"
@@ -98,14 +98,14 @@ class Tram(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override fun vehicleWantsToDriveAt(timestep: Int): Boolean {
         // the vehicle wants to drive if its drive plan says so
         // or if it got previously delayed
-        return wannaDriveInHours.contains(timestep) || delay > 0
+        return wannaDriveInHours.contains(timestep) || lagTillDestination > 0
     }
 
     override fun getDelayedAtHour(timestep: Int) {
-        // if the vehicle wanted to drive, its delay increased
-        // (otherwise it just waited an hour, not reducing its delay)
+        // if the vehicle wanted to drive, its lagTillDestination increased
+        // (otherwise it just waited an hour, not reducing its lagTillDestination)
         if (wannaDriveInHours.contains(timestep)) {
-            delay += 1
+            lagTillDestination += 1
             this.gotNewDelayInHours.add(timestep)
             this.gotNewDelayInHours.sort()
         }
@@ -113,9 +113,9 @@ class Tram(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override fun driveAtHour(timestep: Int) {
         // if the vehicle wanted to drive, it is still as delayed as before
-        // (otherwise it just gained an hour, thus reducing delay)
+        // (otherwise it just gained an hour, thus reducing lagTillDestination)
         if (!wannaDriveInHours.contains(timestep)) {
-            delay -= 1
+            lagTillDestination -= 1
         }
 
         this.droveWithoutNewDelayInHours.add(timestep)
@@ -149,7 +149,7 @@ class Truck(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override val capacityFactor = 30
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    var delay = 0
+    var lagTillDestination = 0
 
     override fun getClass(): String {
         return "Truck"
@@ -162,14 +162,14 @@ class Truck(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override fun vehicleWantsToDriveAt(timestep: Int): Boolean {
         // the vehicle wants to drive if its drive plan says so
         // or if it got previously delayed
-        return wannaDriveInHours.contains(timestep) || delay > 0
+        return wannaDriveInHours.contains(timestep) || lagTillDestination > 0
     }
 
     override fun getDelayedAtHour(timestep: Int) {
-        // if the vehicle wanted to drive, its delay increased
-        // (otherwise it just waited an hour, not reducing its delay)
+        // if the vehicle wanted to drive, its lagTillDestination increased
+        // (otherwise it just waited an hour, not reducing its lagTillDestination)
         if (wannaDriveInHours.contains(timestep)) {
-            delay += 1
+            lagTillDestination += 1
             this.gotNewDelayInHours.add(timestep)
             this.gotNewDelayInHours.sort()
         }
@@ -177,9 +177,9 @@ class Truck(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override fun driveAtHour(timestep: Int) {
         // if the vehicle wanted to drive, it is still as delayed as before
-        // (otherwise it just gained an hour, thus reducing delay)
+        // (otherwise it just gained an hour, thus reducing lagTillDestination)
         if (!wannaDriveInHours.contains(timestep)) {
-            delay -= 1
+            lagTillDestination -= 1
         }
 
         this.droveWithoutNewDelayInHours.add(timestep)
@@ -213,7 +213,7 @@ class Bike(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override val capacityFactor = 1
     override val gotNewDelayInHours: MutableList<Int> = mutableListOf()
     override val droveWithoutNewDelayInHours: MutableList<Int> = mutableListOf()
-    var delay = 0
+    var lagTillDestination = 0
 
     override fun getClass(): String {
         return "Bike"
@@ -226,14 +226,14 @@ class Bike(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
     override fun vehicleWantsToDriveAt(timestep: Int): Boolean {
         // the vehicle wants to drive if its drive plan says so
         // or if it got previously delayed
-        return wannaDriveInHours.contains(timestep) || delay > 0
+        return wannaDriveInHours.contains(timestep) || lagTillDestination > 0
     }
 
     override fun getDelayedAtHour(timestep: Int) {
-        // if the vehicle wanted to drive, its delay increased
-        // (otherwise it just waited an hour, not reducing its delay)
+        // if the vehicle wanted to drive, its lagTillDestination increased
+        // (otherwise it just waited an hour, not reducing its lagTillDestination)
         if (wannaDriveInHours.contains(timestep)) {
-            delay += 1
+            lagTillDestination += 1
             this.gotNewDelayInHours.add(timestep)
             this.gotNewDelayInHours.sort()
         }
@@ -241,9 +241,9 @@ class Bike(val id: Int, val wannaDriveInHours: MutableList<Int>) : Vehicle {
 
     override fun driveAtHour(timestep: Int) {
         // if the vehicle wanted to drive, it is still as delayed as before
-        // (otherwise it just gained an hour, thus reducing delay)
+        // (otherwise it just gained an hour, thus reducing lagTillDestination)
         if (!wannaDriveInHours.contains(timestep)) {
-            delay -= 1
+            lagTillDestination -= 1
         }
 
         this.droveWithoutNewDelayInHours.add(timestep)

--- a/src/test/kotlin/RoadNetworkTest.kt
+++ b/src/test/kotlin/RoadNetworkTest.kt
@@ -178,7 +178,7 @@ class RoadNetworkTest {
         road.simulateScenario(allVehicles)
 
         for (vehicle in allVehicles) {
-            val test: Boolean = ( vehicle.delay > 0 )
+            val test: Boolean = ( vehicle.lagTillDestination > 0 )
             assertEquals(true, test)
         }
     }*//*


### PR DESCRIPTION
Lösung für Issue #102 
Closes #102 

Das Attribut `delay` von allen Unterklassen des Interface `Vehicle` wurde umbenannt zu `lagTillDestination`. Diese Umbenennung soll die Information der Variable besser beschreiben.